### PR TITLE
Use hex dependency and run with elixir 1.3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: elixir
 elixir:
-  - 1.2.6
+  - 1.3.4
 otp_release:
   - 18.3
 

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule Tap.Mixfile do
 
   defp deps do
     [
-      {:recon, git: "https://github.com/ferd/recon.git"},
+      {:recon, "~> 2.3"},
 
       # Documentation
       {:ex_doc,  "~> 0.9", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
 %{"earmark": {:hex, :earmark, "0.1.17", "a2269e72ff85501bdb58c2de9edc0a9a17a4be2757883eed1f601b30494ed2bf", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.9.0", "e59f4550dc78a07b1d3d81b8728fda772cfb0d54bccf1d7e6bcaab32c01c1f3a", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
-  "recon": {:git, "https://github.com/ferd/recon.git", "3e96fddccfa3e736528ae9fe83051877cbc60967", []}}
+  "recon": {:hex, :recon, "2.3.2", "4444c879be323b1b133eec5241cb84bd3821ea194c740d75617e106be4744318", [:rebar3], []}}


### PR DESCRIPTION
This bumps Elixir version in travis.yml (includes the hex dependency)