### PR TITLE
Avoid compiler warnings

### DIFF
--- a/lib/tap.ex
+++ b/lib/tap.ex
@@ -136,8 +136,18 @@ defmodule Tap do
     end
   end
 
+  @doc ~S"""
+
+  Formatting the output
+
+  ## Examples
+
+      iex(1)> Tap.format({{1.0,1.0,1.0},""},"test")
+      "1.0:1.0:1.000000 \"\" test\n\n"
+      
+  """
   def format({{hour, min, sec}, pid}, message) do
-    "#{hour}:#{min}:#{Float.to_string(sec, decimals: 6)} #{inspect pid} #{message}\n\n"
+    "#{hour}:#{min}:#{:erlang.float_to_binary(sec, decimals: 6)} #{inspect pid} #{message}\n\n"
   end
 
   defp expand(specs), do: for(s <- specs, do: spec(s))

--- a/mix.exs
+++ b/mix.exs
@@ -5,12 +5,12 @@ defmodule Tap.Mixfile do
     [
       app: :tap,
       description: "Elixir tracing",
-      package: package,
+      package: package(),
       version: "0.1.4",
       elixir: "~> 1.2",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
-      deps: deps,
+      deps: deps(),
       docs: [extras: ["README.md"]]
     ]
   end


### PR DESCRIPTION
Adds test to format function - replacing deprecated Float.to_string/2
with :erlang.float_to_binary